### PR TITLE
Change capacity fields to string

### DIFF
--- a/client/capacity.go
+++ b/client/capacity.go
@@ -2,7 +2,7 @@ package client
 
 //Capacity capacity for cluster
 type Capacity struct {
-	Desired int `json:"desired"`
-	Max     int `json:"max"`
-	Min     int `json:"min"`
+	Desired string `json:"desired"`
+	Max     string `json:"max"`
+	Min     string `json:"min"`
 }

--- a/provider/capacity.go
+++ b/provider/capacity.go
@@ -1,7 +1,7 @@
 package provider
 
 type capacity struct {
-	Desired int `mapstructure:"desired"`
-	Max     int `mapstructure:"max"`
-	Min     int `mapstructure:"min"`
+	Desired string `mapstructure:"desired"`
+	Max     string `mapstructure:"max"`
+	Min     string `mapstructure:"min"`
 }

--- a/provider/capacity_resource.go
+++ b/provider/capacity_resource.go
@@ -8,15 +8,15 @@ func capacityResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"desired": &schema.Schema{
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"max": &schema.Schema{
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 			"min": &schema.Schema{
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 			},
 		},


### PR DESCRIPTION
It will allow use of pipeline expressions.
https://www.spinnaker.io/guides/user/pipeline/expressions/

Example:
```terraform
  action      = "scale_exact"
  resize_type = "exact"

  capacity {
    desired = "$${ #stage('Webhook stage')['context']['buildInfo']['scalingPolicies']['desired'] }"
    max     = "$${ #stage('Webhook stage')['context']['buildInfo']['scalingPolicies']['max'] }"
    min     = "$${ #stage('Webhook stage')['context']['buildInfo']['scalingPolicies']['min'] }"
  }
```