### PR TITLE
[FEATURE]: Dynamic Security Group and Role Lookups

### DIFF
--- a/client/deploy_stage_cluster.go
+++ b/client/deploy_stage_cluster.go
@@ -27,7 +27,7 @@ type DeployStageCluster struct {
 	Provider                            string                 `json:"provider"`
 	Rollback                            *Rollback              `json:"rollback"`
 	ScaleDown                           bool                   `json:"scaleDown"`
-	SecurityGroups                      []string               `json:"securityGroups"`
+	SecurityGroups                      interface{}            `json:"securityGroups"`
 	SpelLoadBalancers                   []string               `json:"spelLoadBalancers"`
 	SpelTargetGroups                    []string               `json:"spelTargetGroups"`
 	SpotPrice                           string                 `json:"spotPrice"`

--- a/client/webhook_stage.go
+++ b/client/webhook_stage.go
@@ -32,7 +32,7 @@ type serializableWebhookStage struct {
 	CustomHeaders       map[string]string `json:"customHeaders"`
 	FailFastStatusCodes []string          `json:"failFastStatusCodes"`
 	Method              string            `json:"method"`
-	Payload             map[string]string `json:"payload"`
+	Payload             map[string]interface{} `json:"payload"`
 	ProgressJSONPath    string            `json:"progressJsonPath"`
 	StatusJSONPath      string            `json:"statusJsonPath"`
 	StatusURLJSONPath   string            `json:"statusUrlJsonPath"`

--- a/provider/application_resource.go
+++ b/provider/application_resource.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"errors"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/jgramoll/terraform-provider-spinnaker/client"
@@ -11,6 +13,10 @@ import (
 const (
 	// ApplicationKey key for application in map
 	ApplicationKey = "application"
+)
+
+var (
+	ApplicationNameRegex = regexp.MustCompile("^[a-zA-Z_0-9.]*$")
 )
 
 func applicationResource() *schema.Resource {
@@ -116,6 +122,9 @@ func resourceApplicationCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	log.Println("[DEBUG] Creating application:", application.Name)
+	if !ApplicationNameRegex.MatchString(application.Name) || len(application.Name) > 249 {
+		return errors.New("application name can't have special characters or spaces and must be shorter than 250 characters")
+	}
 	applicationService := m.(*Services).ApplicationService
 	err := applicationService.CreateApplication(application.toClientApplication())
 	if err != nil {

--- a/provider/deploy_stage_cluster.go
+++ b/provider/deploy_stage_cluster.go
@@ -28,7 +28,8 @@ type deployStageCluster struct {
 	LoadBalancers                       []string               `mapstructure:"load_balancers"`
 	Moniker                             *[]*moniker            `mapstructure:"moniker"`
 	Provider                            string                 `mapstructure:"provider"`
-	SecurityGroups                      []string               `mapstructure:"security_groups"`
+	SecurityGroups                      interface{}            `mapstructure:"security_groups"`
+	SecurityGroupsExpression            string                 `mapstructure:"security_groups_expression"`
 	SpelLoadBalancers                   []string               `mapstructure:"spel_load_balancers"`
 	SpelTargetGroups                    []string               `mapstructure:"spel_target_groups"`
 	SpotPrice                           string                 `mapstructure:"spot_price"`
@@ -92,7 +93,11 @@ func (c *deployStageCluster) toClientCluster() *client.DeployStageCluster {
 	clientCluster.LoadBalancers = c.LoadBalancers
 	clientCluster.Moniker = toClientMoniker(c.Moniker)
 	clientCluster.Provider = c.Provider
-	clientCluster.SecurityGroups = c.SecurityGroups
+	if c.SecurityGroupsExpression != "" {
+		clientCluster.SecurityGroups = c.SecurityGroupsExpression
+	} else {
+		clientCluster.SecurityGroups = c.SecurityGroups
+	}
 	clientCluster.SpelLoadBalancers = c.SpelLoadBalancers
 	clientCluster.SpelTargetGroups = c.SpelTargetGroups
 	clientCluster.SpotPrice = c.SpotPrice
@@ -122,6 +127,15 @@ func (s *deployStage) toClientClusters() *[]*client.DeployStageCluster {
 }
 
 func fromClientCluster(c *client.DeployStageCluster) *deployStageCluster {
+	var sgs []string
+	var sgExpression string
+	switch v := c.SecurityGroups.(type) {
+	case string:
+		sgExpression = v
+	case []string:
+		sgs = v
+	}
+
 	newCluster := deployStageCluster{
 		Account:       c.Account,
 		Application:   c.Application,
@@ -130,28 +144,29 @@ func fromClientCluster(c *client.DeployStageCluster) *deployStageCluster {
 
 		CopySourceCustomBlockDeviceMappings: c.CopySourceCustomBlockDeviceMappings,
 
-		EBSOptimized:           c.EBSOptimized,
-		EnabledMetrics:         c.EnabledMetrics,
-		FreeFormDetails:        c.FreeFormDetails,
-		HealthCheckGracePeriod: c.HealthCheckGracePeriod,
-		HealthCheckType:        c.HealthCheckType,
-		IAMRole:                c.IAMRole,
-		InstanceMonitoring:     c.InstanceMonitoring,
-		InstanceType:           c.InstanceType,
-		KeyPair:                c.KeyPair,
-		MaxRemainingAsgs:       c.MaxRemainingAsgs,
-		LoadBalancers:          c.LoadBalancers,
-		Provider:               c.Provider,
-		SecurityGroups:         c.SecurityGroups,
-		SpelLoadBalancers:      c.SpelLoadBalancers,
-		SpelTargetGroups:       c.SpelTargetGroups,
-		SpotPrice:              c.SpotPrice,
-		Stack:                  c.Stack,
-		Strategy:               c.Strategy,
-		SubnetType:             c.SubnetType,
-		SuspendedProcesses:     c.SuspendedProcesses,
-		Tags:                   c.Tags,
-		TargetGroups:           c.TargetGroups,
+		EBSOptimized:             c.EBSOptimized,
+		EnabledMetrics:           c.EnabledMetrics,
+		FreeFormDetails:          c.FreeFormDetails,
+		HealthCheckGracePeriod:   c.HealthCheckGracePeriod,
+		HealthCheckType:          c.HealthCheckType,
+		IAMRole:                  c.IAMRole,
+		InstanceMonitoring:       c.InstanceMonitoring,
+		InstanceType:             c.InstanceType,
+		KeyPair:                  c.KeyPair,
+		MaxRemainingAsgs:         c.MaxRemainingAsgs,
+		LoadBalancers:            c.LoadBalancers,
+		Provider:                 c.Provider,
+		SecurityGroups:           sgs,
+		SecurityGroupsExpression: sgExpression,
+		SpelLoadBalancers:        c.SpelLoadBalancers,
+		SpelTargetGroups:         c.SpelTargetGroups,
+		SpotPrice:                c.SpotPrice,
+		Stack:                    c.Stack,
+		Strategy:                 c.Strategy,
+		SubnetType:               c.SubnetType,
+		SuspendedProcesses:       c.SuspendedProcesses,
+		Tags:                     c.Tags,
+		TargetGroups:             c.TargetGroups,
 
 		TargetHealthyDeployPercentage: c.TargetHealthyDeployPercentage,
 		TerminationPolicies:           c.TerminationPolicies,

--- a/provider/deploy_stage_cluster_resource.go
+++ b/provider/deploy_stage_cluster_resource.go
@@ -288,6 +288,11 @@ func pipelineDeployStageClusterResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"security_groups_expression": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Security Group expression -- will override other sg inputs",
+				Optional:    true,
+			},
 			"spel_load_balancers": &schema.Schema{
 				Type:        schema.TypeList,
 				Description: "spel load balancers to attach to cluster",

--- a/provider/pipeline_webhook_stage_resource.go
+++ b/provider/pipeline_webhook_stage_resource.go
@@ -185,8 +185,8 @@ func pipelineWebhookStageResource() *schema.Resource {
 				Optional:    true,
 				Default:     "GET",
 			},
-			"payload": &schema.Schema{
-				Type:        schema.TypeMap,
+			"payload_string": &schema.Schema{
+				Type:        schema.TypeString,
 				Description: "JSON payload to be added to the webhook call.",
 				Optional:    true,
 			},


### PR DESCRIPTION
Adding the ability to override the security groups with an expression. This allows us to receive security groups from DCS. If no expression is set, the default list is used.

Also modified the payload for the webhook stage to take a string, this allows it to be more flexible as terraform only allows map[string]string for map inputs.