### PR TITLE
[Hack] fix spinnaker error

### DIFF
--- a/client/spinnaker_error.go
+++ b/client/spinnaker_error.go
@@ -10,8 +10,8 @@ type SpinnakerError struct {
 	Exception string `json:"exception"`
 	Message   string `json:"message"`
 	Status    int    `json:"status"`
-	Timestamp int64  `json:"timestamp"`
-	Body      string `json:"body"`
+	// Timestamp int64  `json:"timestamp"` // HACK - this is breaking application_resource
+	Body string `json:"body"`
 }
 
 // For error interface


### PR DESCRIPTION
In application_resource.go, we call applicationService.GetApplicationByName. That will return a 404 for applications that don't exist. We expect that and handle it correctly. However, when we deserialize the error, it throws an exception because SpinnakerError.Timestamp is a string and not an int64.If we change SpinnakerError.Timestamp to a string, then it breaks when trying to deserialize the error when we are checking if pipelines exist. 

We need to figure out the root of this problem at some point. For now, let's just get rid of the timestamp since we aren't using it. That will unblock much more important work.