### PR TITLE
Base64 certs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ terraform-provider-spinnaker
 coverage.out
 report.json
 .envrc
+.vscode/*
+.idea/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+export GO111MODULE := on
+DIST_DIR ?= ${PWD}/bin
+HOME := ${HOME}
+PROJECT_NAME := terraform-provider-spinnaker
+
+.PHONY: help
+help:  ## Show help messages for make targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: setup
+setup: ## Download tools required to check and build
+ifeq ($(shell uname -s), Darwin)
+	@brew install golangci-lint
+else
+	@curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh
+endif
+
+.PHONY: build
+build: ## Download dependencies and compile project
+	@CGO_ENABLED=0 go build -o ${DIST_DIR}/${PROJECT_NAME} main.go
+
+.PHONY: install
+install: build ## Builds and installs the terraform provider
+	@cp ${DIST_DIR}/${PROJECT_NAME} ${HOME}/.terraform.d/plugins/
+
+.PHONY: lint
+lint: ## Runs go lint checks
+	@golangci-lint run ./...
+
+.PHONY: test
+test: ## Runs go tests
+	@go test --cover ./...
+
+.PHONY: test
+acc: ## Runs go acceptance tests
+	@TF_ACC=1 go test -v --cover ./...

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -69,14 +69,14 @@ func Provider() terraform.ResourceProvider {
 							Description: "Path to key to authenticate with spinnaker api",
 						},
 
-						"cert_path_content": &schema.Schema{
+						"cert_content": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    false,
 							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_CERT_CONTENT", nil),
 							Description: "Cert string in base64 to authenticate with spinnaker api",
 						},
 
-						"key_path_content": &schema.Schema{
+						"key_content": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    false,
 							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_KEY_CONTENT", nil),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -73,14 +73,14 @@ func Provider() terraform.ResourceProvider {
 							Type:        schema.TypeString,
 							Required:    false,
 							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_CERT_CONTENT", nil),
-							Description: "Cert string to authenticate with spinnaker api",
+							Description: "Cert string in base64 to authenticate with spinnaker api",
 						},
 
 						"key_path_content": &schema.Schema{
 							Type:        schema.TypeString,
 							Required:    false,
 							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_KEY_CONTENT", nil),
-							Description: "Key string to authenticate with spinnaker api",
+							Description: "Key string in base64 to authenticate with spinnaker api",
 						},
 
 						"user_email": &schema.Schema{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -24,10 +24,12 @@ type Config struct {
 
 // Auth for provider
 type Auth struct {
-	Enabled   bool   `mapstructure:"enabled"`
-	CertPath  string `mapstructure:"cert_path"`
-	KeyPath   string `mapstructure:"key_path"`
-	UserEmail string `mapstructure:"user_email"`
+	Enabled     bool   `mapstructure:"enabled"`
+	CertPath    string `mapstructure:"cert_path"`
+	KeyPath     string `mapstructure:"key_path"`
+	CertContent string `mapstructure:"cert_content"`
+	KeyContent  string `mapstructure:"key_content"`
+	UserEmail   string `mapstructure:"user_email"`
 }
 
 // Provider for terraform
@@ -65,6 +67,20 @@ func Provider() terraform.ResourceProvider {
 							Required:    false,
 							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_KEY", nil),
 							Description: "Path to key to authenticate with spinnaker api",
+						},
+
+						"cert_path_content": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    false,
+							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_CERT_CONTENT", nil),
+							Description: "Cert string to authenticate with spinnaker api",
+						},
+
+						"key_path_content": &schema.Schema{
+							Type:        schema.TypeString,
+							Required:    false,
+							DefaultFunc: schema.EnvDefaultFunc("SPINNAKER_KEY_CONTENT", nil),
+							Description: "Key string to authenticate with spinnaker api",
 						},
 
 						"user_email": &schema.Schema{
@@ -114,13 +130,18 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	clientConfig := client.Config{
 		Address: config.Address,
 		Auth: client.Auth{
-			Enabled:   config.Auth.Enabled,
-			CertPath:  config.Auth.CertPath,
-			KeyPath:   config.Auth.KeyPath,
-			UserEmail: config.Auth.UserEmail,
+			Enabled:     config.Auth.Enabled,
+			CertPath:    config.Auth.CertPath,
+			KeyPath:     config.Auth.KeyPath,
+			CertContent: config.Auth.CertContent,
+			KeyContent:  config.Auth.KeyContent,
+			UserEmail:   config.Auth.UserEmail,
 		},
 	}
-	c := client.NewClient(clientConfig)
+	c, err := client.NewClient(clientConfig)
+	if err != nil {
+		return nil, err
+	}
 	return &Services{
 		Config:             clientConfig,
 		ApplicationService: client.ApplicationService{Client: c},

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"log"
+	"os"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
@@ -137,6 +138,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			KeyContent:  config.Auth.KeyContent,
 			UserEmail:   config.Auth.UserEmail,
 		},
+	}
+	if v := os.Getenv("SPINNAKER_CERT"); v != "" {
+		clientConfig.Auth.CertPath = v
+		clientConfig.Auth.KeyPath = os.Getenv("SPINNAKER_KEY")
+	}
+	if v := os.Getenv("SPINNAKER_CERT_CONTENT"); v != "" {
+		clientConfig.Auth.CertContent = v
+		clientConfig.Auth.KeyContent = os.Getenv("SPINNAKER_KEY_CONTENT")
 	}
 	c, err := client.NewClient(clientConfig)
 	if err != nil {


### PR DESCRIPTION
Enable key-pair configuration using base64 inputs. For some automation, the environment variables are the easier way to configure those entries avoiding the need to generate the file and set the env to the path. The solution with content will be more straightforward.

Also, changed the certificate configuration to return the error helping the terraform interactions.

Latest, added makefile to simplify the installation and other commands.