### PR TITLE
Add application permissions field

### DIFF
--- a/client/application.go
+++ b/client/application.go
@@ -20,6 +20,7 @@ type Application struct {
 	RepoType                       string            `json:"repoType"`
 	RepoProjectKey                 string            `json:"repoProjectKey"`
 	RepoSlug                       string            `json:"repoSlug"`
+	Permissions                    *Permissions      `json:"permissions"`
 	PlatformHealthOnly             bool              `json:"platformHealthOnly"`
 	PlatformHealthOnlyShowOverride bool              `json:"platformHealthOnlyShowOverride"`
 	EnableRestartRunningExecutions bool              `json:"enableRestartRunningExecutions"`
@@ -28,6 +29,13 @@ type Application struct {
 // ApplicationAttributes mapping for `application/{appName}`  endpoint
 type ApplicationAttributes struct {
 	Application *Application `json:"attributes"`
+}
+
+// Permissions define the authorized groups access
+type Permissions struct {
+	Read    []string `json:"READ"`
+	Execute []string `json:"EXECUTE"`
+	Write   []string `json:"WRITE"`
 }
 
 // NewAwsProviderSettings return Aws provider settings with default values

--- a/provider/application_resource.go
+++ b/provider/application_resource.go
@@ -83,6 +83,39 @@ func applicationResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"permissions": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"read": &schema.Schema{
+							Type:        schema.TypeList,
+							Description: "Read access group/user list",
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"execute": &schema.Schema{
+							Type:        schema.TypeList,
+							Description: "Execute access group/user list. Non before spin v1.14.*",
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"write": &schema.Schema{
+							Type:        schema.TypeList,
+							Description: "Write access group/user list",
+							Optional:    true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 			"provider_settings": &schema.Schema{
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/provider/application_test.go
+++ b/provider/application_test.go
@@ -73,6 +73,43 @@ func TestAccApplicationTrigger(t *testing.T) {
 	})
 }
 
+func TestAccApplicationPermissions(t *testing.T) {
+	var applicationRef client.Application
+	name := acctest.RandStringFromCharSet(50, acctest.CharSetAlphaNum)
+	resourceName := "spinnaker_application.permissions"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckApplicationDestroy,
+		Steps: []resource.TestStep{{
+			Config: fmt.Sprintf(`resource "spinnaker_application" "permissions" {
+					name  		 = "%s"
+					email 		 = "%s@spin.com"
+					instance_port  = "8080"
+					
+					cloud_providers = [
+						"aws"
+					]
+					
+					permissions {
+						read  = ["qa"]
+						write = ["dev"]
+					}
+				}`, name, name),
+			Check: resource.ComposeAggregateTestCheckFunc(
+				testAccCheckApplicationExists(resourceName, &applicationRef),
+				resource.TestCheckResourceAttr(resourceName, "name", name),
+				resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "permissions.0.read.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "permissions.0.read.0", "qa"),
+				resource.TestCheckResourceAttr(resourceName, "permissions.0.write.#", "1"),
+				resource.TestCheckResourceAttr(resourceName, "permissions.0.write.0", "dev"),
+			),
+		}},
+	})
+}
+
 func testAccApplicationConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "spinnaker_application" "test" {

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -152,10 +152,12 @@ func providerConfigure(d *schema.ResourceData, terraformVersion string) (interfa
 		},
 	}
 	if v := os.Getenv("SPINNAKER_CERT"); v != "" {
+		clientConfig.Auth.Enabled = true
 		clientConfig.Auth.CertPath = v
 		clientConfig.Auth.KeyPath = os.Getenv("SPINNAKER_KEY")
 	}
 	if v := os.Getenv("SPINNAKER_CERT_CONTENT"); v != "" {
+		clientConfig.Auth.Enabled = true
 		clientConfig.Auth.CertContent = v
 		clientConfig.Auth.KeyContent = os.Getenv("SPINNAKER_KEY_CONTENT")
 	}


### PR DESCRIPTION
This will allow restriction configuration for non-authorized access. One note is that you will need to properly configure the roles if you are using x509 - check the role OID or use the same user as an existing role.

To test it you will need to configure the following envs:
* **SPINNAKER_ADDRESS** I.e. https://my.gate.com:8084
* **SPINNAKER_CERT_CONTENT** base64 of certs or use the **SPINNAKER_CERT**
* **SPINNAKER_KEY_CONTENT** base64 of certs or use the **SPINNAKER_KEY**

Another issue that I got was to give right permissions to my x509. You will need to configure the roleOID -> [#creating-an-x509-client-certificate-with-user-role-information][1]. I had issues maybe due my old spinnaker version. I ended using same user as a valid role.

Running the specific test:
```bash
$ TF_ACC=true go test -timeout 30s github.com/jgramoll/terraform-provider-spinnaker/provider -run TestAccApplicationPermissions -v -count
=== RUN   TestAccApplicationPermissions
--- PASS: TestAccApplicationPermissions (10.82s)
PASS
ok      github.com/jgramoll/terraform-provider-spinnaker/provider       10.851s
```

[1]: https://www.spinnaker.io/setup/security/authentication/x509/#creating-an-x509-client-certificate-with-user-role-information